### PR TITLE
[Feature] vault refresh callback and helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kibibit/configit",
-  "version": "2.12.2-beta.1",
+  "version": "2.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kibibit/configit",
-      "version": "2.12.2-beta.1",
+      "version": "2.12.2",
       "license": "MIT",
       "dependencies": {
         "@kibibit/kb-error": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2106,6 +2106,19 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@profoundlogic/hogan": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@profoundlogic/hogan/-/hogan-3.0.4.tgz",
+      "integrity": "sha512-pmNVGuooS30Mm7YbZd5T7E5zYVO6D5Ct91sn4T39mUvMUc3sCGridcnhAufL1/Bz2QzAtzEn0agNrdk3+5yWzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "nopt": "1.0.10"
+      },
+      "bin": {
+        "hulk": "bin/hulk"
+      }
+    },
     "node_modules/@semantic-release/changelog": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
@@ -2939,7 +2952,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -4673,26 +4687,28 @@
       }
     },
     "node_modules/diff2html": {
-      "version": "3.4.13",
-      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-3.4.13.tgz",
-      "integrity": "sha512-IQb+P3aDVjjctcpRF089E9Uxjb6JInu/1SDklLaw2KapdwXKl3xd87mieweR2h6hNvdyAlylMHRrwK8M4oV1Sw==",
+      "version": "3.4.56",
+      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-3.4.56.tgz",
+      "integrity": "sha512-u9gfn+BlbHcyO7vItCIC4z49LJDUt31tODzOfAuJ5R1E7IdlRL6KjugcB9zOpejD+XiR+dDZbsnHSQ3g6A/u8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "diff": "5.0.0",
-        "hogan.js": "3.0.2"
+        "@profoundlogic/hogan": "^3.0.4",
+        "diff": "^8.0.3"
       },
       "engines": {
         "node": ">=12"
       },
       "optionalDependencies": {
-        "highlight.js": "11.2.0"
+        "highlight.js": "11.11.1"
       }
     },
     "node_modules/diff2html/node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -6617,10 +6633,11 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-      "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
         "node": ">=12.0.0"
@@ -6632,44 +6649,6 @@
       "integrity": "sha512-MkUeB0cTIlppeSsndgESkfFD21T2nXPRaBStLtf3cAYA2bVEFdXlodZB0TukwZiobPD1Ksax5DK4RTZeaXCI3Q==",
       "bin": {
         "hjson": "bin/hjson"
-      }
-    },
-    "node_modules/hogan.js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
-      "integrity": "sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=",
-      "dev": true,
-      "dependencies": {
-        "mkdirp": "0.3.0",
-        "nopt": "1.0.10"
-      },
-      "bin": {
-        "hulk": "bin/hulk"
-      }
-    },
-    "node_modules/hogan.js/node_modules/mkdirp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-      "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/hogan.js/node_modules/nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/holderjs": {
@@ -8039,10 +8018,11 @@
       }
     },
     "node_modules/jest-stare": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/jest-stare/-/jest-stare-2.5.0.tgz",
-      "integrity": "sha512-2pYfbDHIC2Aae/hcFaYFXVQYCqBmlgShxuUSrwf7g1s+br+4W6T0+QUfO+khqFDYCDJFCtG8LIbRSzrKOCQmWw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/jest-stare/-/jest-stare-2.5.3.tgz",
+      "integrity": "sha512-HXykqTNNxguOQZiWCEcUPC5HleaVngQysyyniG6LzoeBsM4dtq4YDw/JruS2ChfRBS/9PUcG04eAx6NdcbFDDg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/reporters": "^29.0.0",
         "@jest/test-result": "^29.0.0",
@@ -8052,7 +8032,7 @@
         "bootstrap": "^5.0.0",
         "chalk": "^4.1.0",
         "chart.js": "^4.1.2",
-        "diff2html": "^3.1.18",
+        "diff2html": "^3.4.40",
         "holderjs": "^2.9.7",
         "jquery": "^3.5.1",
         "moment": "^2.27.0",
@@ -9331,6 +9311,22 @@
       },
       "engines": {
         "npm": ">=1.4.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/normalize-path": {
@@ -16986,6 +16982,15 @@
       "dev": true,
       "peer": true
     },
+    "@profoundlogic/hogan": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@profoundlogic/hogan/-/hogan-3.0.4.tgz",
+      "integrity": "sha512-pmNVGuooS30Mm7YbZd5T7E5zYVO6D5Ct91sn4T39mUvMUc3sCGridcnhAufL1/Bz2QzAtzEn0agNrdk3+5yWzw==",
+      "dev": true,
+      "requires": {
+        "nopt": "1.0.10"
+      }
+    },
     "@semantic-release/changelog": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
@@ -18903,20 +18908,20 @@
       "dev": true
     },
     "diff2html": {
-      "version": "3.4.13",
-      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-3.4.13.tgz",
-      "integrity": "sha512-IQb+P3aDVjjctcpRF089E9Uxjb6JInu/1SDklLaw2KapdwXKl3xd87mieweR2h6hNvdyAlylMHRrwK8M4oV1Sw==",
+      "version": "3.4.56",
+      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-3.4.56.tgz",
+      "integrity": "sha512-u9gfn+BlbHcyO7vItCIC4z49LJDUt31tODzOfAuJ5R1E7IdlRL6KjugcB9zOpejD+XiR+dDZbsnHSQ3g6A/u8A==",
       "dev": true,
       "requires": {
-        "diff": "5.0.0",
-        "highlight.js": "11.2.0",
-        "hogan.js": "3.0.2"
+        "@profoundlogic/hogan": "^3.0.4",
+        "diff": "^8.0.3",
+        "highlight.js": "11.11.1"
       },
       "dependencies": {
         "diff": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+          "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
           "dev": true
         }
       }
@@ -20358,9 +20363,9 @@
       }
     },
     "highlight.js": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-      "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "dev": true,
       "optional": true
     },
@@ -20368,33 +20373,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/hjson/-/hjson-3.2.2.tgz",
       "integrity": "sha512-MkUeB0cTIlppeSsndgESkfFD21T2nXPRaBStLtf3cAYA2bVEFdXlodZB0TukwZiobPD1Ksax5DK4RTZeaXCI3Q=="
-    },
-    "hogan.js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
-      "integrity": "sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.3.0",
-        "nopt": "1.0.10"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-          "dev": true
-        },
-        "nopt": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        }
-      }
     },
     "holderjs": {
       "version": "2.9.9",
@@ -21389,9 +21367,9 @@
       }
     },
     "jest-stare": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/jest-stare/-/jest-stare-2.5.0.tgz",
-      "integrity": "sha512-2pYfbDHIC2Aae/hcFaYFXVQYCqBmlgShxuUSrwf7g1s+br+4W6T0+QUfO+khqFDYCDJFCtG8LIbRSzrKOCQmWw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/jest-stare/-/jest-stare-2.5.3.tgz",
+      "integrity": "sha512-HXykqTNNxguOQZiWCEcUPC5HleaVngQysyyniG6LzoeBsM4dtq4YDw/JruS2ChfRBS/9PUcG04eAx6NdcbFDDg==",
       "dev": true,
       "requires": {
         "@jest/reporters": "^29.0.0",
@@ -21402,7 +21380,7 @@
         "bootstrap": "^5.0.0",
         "chalk": "^4.1.0",
         "chart.js": "^4.1.2",
-        "diff2html": "^3.1.18",
+        "diff2html": "^3.4.40",
         "holderjs": "^2.9.7",
         "jquery": "^3.5.1",
         "moment": "^2.27.0",
@@ -22388,6 +22366,15 @@
           "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
           "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ=="
         }
+      }
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
       }
     },
     "normalize-path": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kibibit/configit",
-  "version": "2.12.2-beta.1",
+  "version": "2.12.2",
   "description": "a general typescript configuration service",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/scripts/test-vault-dynamic.ts
+++ b/scripts/test-vault-dynamic.ts
@@ -17,7 +17,8 @@ import {
   VaultEngine,
   VaultIntegration,
   VaultProvider,
-  IVaultConfigOptions
+  IVaultConfigOptions,
+  SecretRefreshEvent
 } from '../src/vault';
 
 // ============================================
@@ -25,26 +26,28 @@ import {
 // ============================================
 class DynamicSecretsConfig {
   // Static KV v2 secret (no TTL)
-  @VaultPath('secret/data/configit/api')
+  @VaultPath('configit/api')
   @VaultKey('api_key')
   @VaultEngine('kv-v2')
   @IsString()
   API_KEY!: string;
 
   // Dynamic database credential (60s TTL!)
-  @VaultPath('database/creds/configit-readonly')
+  @VaultPath('creds/configit-readonly')
   @VaultKey('username')
   @VaultEngine('database')
   @IsString()
   DB_USERNAME!: string;
 
   // Dynamic database credential (60s TTL!)
-  @VaultPath('database/creds/configit-readonly')
+  @VaultPath('creds/configit-readonly')
   @VaultKey('password')
   @VaultEngine('database')
   @IsString()
   DB_PASSWORD!: string;
 }
+
+const refreshEvents: SecretRefreshEvent[] = [];
 
 const VAULT_CONFIG: IVaultConfigOptions = {
   endpoint: 'http://127.0.0.1:8200',
@@ -52,7 +55,15 @@ const VAULT_CONFIG: IVaultConfigOptions = {
     methods: [{ type: 'token', config: { type: 'token', token: 'configit-dev-token' } }]
   },
   tls: { enabled: false, verifyCertificate: false },
-  refreshBuffer: 30 // Refresh 30 seconds before expiry
+  refreshBuffer: 30, // Refresh 30 seconds before expiry
+  onSecretRefreshed: (event: SecretRefreshEvent) => {
+    refreshEvents.push(event);
+    console.log(`  \x1b[35m[CALLBACK]\x1b[0m Secret refreshed!`);
+    console.log(`    Path: ${ event.vaultPath }`);
+    console.log(`    Properties: ${ event.properties.join(', ') }`);
+    console.log(`    Engine: ${ event.engine }`);
+    console.log(`    Refresh #${ event.refreshCount }`);
+  }
 };
 
 async function runDynamicSecretsTest() {
@@ -150,6 +161,20 @@ async function runDynamicSecretsTest() {
     console.log(`  DB credentials rotated: ${ dbRotated ? '\x1b[32m✓\x1b[0m' : '\x1b[31m✗\x1b[0m (may need more time)' }`);
     console.log('');
 
+    // Step 7: Verify onSecretRefreshed callback
+    console.log('\x1b[1;33mStep 7: Verifying onSecretRefreshed callback...\x1b[0m');
+    const callbackFired = refreshEvents.length > 0;
+    console.log(`  Callback events received: ${ refreshEvents.length } ${ callbackFired ? '\x1b[32m✓\x1b[0m' : '\x1b[31m✗\x1b[0m' }`);
+    if (callbackFired) {
+      const dbEvent = refreshEvents.find((e) => e.engine === 'database');
+      if (dbEvent) {
+        const bothProps = dbEvent.properties.includes('DB_USERNAME') && dbEvent.properties.includes('DB_PASSWORD');
+        console.log(`  DB event includes both properties: ${ bothProps ? '\x1b[32m✓\x1b[0m' : '\x1b[31m✗\x1b[0m' }`);
+        console.log(`  Single event for path (atomic): \x1b[32m✓\x1b[0m (not 2 separate events)`);
+      }
+    }
+    console.log('');
+
     // Summary
     console.log('\x1b[1;34m' + '='.repeat(60) + '\x1b[0m');
     if (apiKeyUnchanged) {
@@ -159,6 +184,9 @@ async function runDynamicSecretsTest() {
         console.log('\x1b[32m    - Dynamic secrets were rotated based on TTL\x1b[0m');
       } else {
         console.log('\x1b[33m    - Dynamic secrets not rotated yet (TTL ~60s, may need more time)\x1b[0m');
+      }
+      if (callbackFired) {
+        console.log('\x1b[32m    - onSecretRefreshed callback fired correctly\x1b[0m');
       }
     } else {
       console.log('\x1b[31m  ✗ Unexpected behavior\x1b[0m');

--- a/src/config.service.ts
+++ b/src/config.service.ts
@@ -22,7 +22,7 @@ import * as nconfJsoncFormat from '@kibibit/nconf-jsonc';
 import { ConfigValidationError } from './config.errors';
 import { BaseConfig } from './config.model';
 import { getEnvironment, setEnvironment } from './environment.service';
-import { IVaultConfigOptions, VaultHealth, VaultIntegration } from './vault';
+import { IVaultConfigOptions, SecretRefreshCallback, VaultHealth, VaultIntegration } from './vault';
 
 type INconfKibibitFormats = IFormats & {
   yaml: nconfYamlFormat;
@@ -296,6 +296,26 @@ export class ConfigService<T extends BaseConfig> {
   invalidateVaultProperty(propertyName: string): void {
     if (this.vaultIntegration) {
       this.vaultIntegration.invalidateProperty(propertyName);
+    }
+  }
+
+  /**
+   * Register a callback for when Vault secrets are refreshed.
+   * Fired once per Vault path after all properties from that path are updated.
+   * Config values are already set when the callback fires.
+   *
+   * Can be called before or after initializeVault().
+   *
+   * @example
+   * configService.onSecretRefreshed((event) => {
+   *   if (event.properties.includes('DB_PASSWORD')) {
+   *     // Reconnect database pool with fresh credentials
+   *   }
+   * });
+   */
+  onSecretRefreshed(callback: SecretRefreshCallback): void {
+    if (this.vaultIntegration) {
+      this.vaultIntegration.onSecretRefreshed(callback);
     }
   }
 

--- a/src/config.service.vault.spec.ts
+++ b/src/config.service.vault.spec.ts
@@ -77,7 +77,8 @@ describe('ConfigService + Vault Integration', () => {
       invalidateProperty: jest.fn(),
       shutdown: jest.fn(),
       isInitialized: jest.fn().mockReturnValue(true),
-      getSecret: jest.fn().mockReturnValue(null)
+      getSecret: jest.fn().mockReturnValue(null),
+      onSecretRefreshed: jest.fn()
     } as unknown as jest.Mocked<VaultIntegration>;
 
     // Ensure the mock implementation returns our mock instance
@@ -856,6 +857,51 @@ describe('ConfigService + Vault Integration', () => {
       );
 
       await expect(configService.initializeVault()).rejects.toThrow('Failed to load secrets');
+    });
+  });
+
+  describe('onSecretRefreshed', () => {
+    it('should delegate callback registration to vaultIntegration', async () => {
+      const vaultConfig: IVaultConfigOptions = {
+        endpoint: 'http://localhost:8200',
+        auth: {
+          methods: [
+            {
+              type: 'token',
+              config: {
+                type: 'token',
+                token: 'test-token'
+              }
+            }
+          ]
+        }
+      };
+
+      const configService = new ConfigService(TestVaultConfig, {
+        NODE_ENV: 'test',
+        REGULAR_CONFIG: 'regular'
+      } as any, {
+        vault: vaultConfig
+      });
+
+      await configService.initializeVault();
+
+      const callback = jest.fn();
+      configService.onSecretRefreshed(callback);
+
+      expect(mockVaultIntegration.onSecretRefreshed).toHaveBeenCalledWith(callback);
+    });
+
+    it('should be a no-op when vault is not configured', () => {
+      const configService = new ConfigService(TestRegularConfig, {
+        NODE_ENV: 'test',
+        REGULAR_CONFIG: 'test-value'
+      } as any);
+
+      const callback = jest.fn();
+      configService.onSecretRefreshed(callback);
+
+      expect(mockVaultIntegration.onSecretRefreshed).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/vault/__tests__/build-vault-config.spec.ts
+++ b/src/vault/__tests__/build-vault-config.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for buildVaultConfigFromEnv helper.
+ * These are pure unit tests — no running Vault instance required.
+ */
+
+import { buildVaultConfigFromEnv } from '../build-vault-config';
+
+describe('buildVaultConfigFromEnv', () => {
+  const ENV_KEYS = ['VAULT_ADDR', 'VAULT_TOKEN', 'VAULT_GCP_ROLE'] as const;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it('should return undefined when VAULT_ADDR is not set', () => {
+    expect(buildVaultConfigFromEnv()).toBeUndefined();
+  });
+
+  it('should return undefined when VAULT_ADDR is set but no auth env var is present', () => {
+    process.env.VAULT_ADDR = 'http://127.0.0.1:8200';
+    expect(buildVaultConfigFromEnv()).toBeUndefined();
+  });
+
+  describe('token auth (VAULT_TOKEN)', () => {
+    beforeEach(() => {
+      process.env.VAULT_ADDR = 'https://vault.example.com';
+      process.env.VAULT_TOKEN = 'my-dev-token';
+    });
+
+    it('should build config with token auth', () => {
+      const config = buildVaultConfigFromEnv();
+
+      expect(config).toBeDefined();
+      expect(config!.endpoint).toBe('https://vault.example.com');
+      expect(config!.auth).toEqual({ method: 'token', token: 'my-dev-token' });
+    });
+
+    it('should default refreshBuffer to 10 for token auth', () => {
+      const config = buildVaultConfigFromEnv();
+      expect(config!.refreshBuffer).toBe(10);
+    });
+
+    it('should allow overriding refreshBuffer', () => {
+      const config = buildVaultConfigFromEnv({ refreshBuffer: 45 });
+      expect(config!.refreshBuffer).toBe(45);
+    });
+
+    it('should apply default fallback config', () => {
+      const config = buildVaultConfigFromEnv();
+
+      expect(config!.fallback).toEqual({
+        required: false,
+        useCacheOnFailure: true,
+        maxCacheAge: 3600000,
+        failFast: false
+      });
+    });
+
+    it('should allow overriding fallback config', () => {
+      const customFallback = { required: true, useCacheOnFailure: false, maxCacheAge: 0, failFast: true };
+      const config = buildVaultConfigFromEnv({ fallback: customFallback });
+      expect(config!.fallback).toEqual(customFallback);
+    });
+
+    it('should wire through onSecretRefreshed callback', () => {
+      const callback = jest.fn();
+      const config = buildVaultConfigFromEnv({ onSecretRefreshed: callback });
+      expect(config!.onSecretRefreshed).toBe(callback);
+    });
+
+    it('should prefer VAULT_TOKEN over VAULT_GCP_ROLE when both are set', () => {
+      process.env.VAULT_GCP_ROLE = 'my-gcp-role';
+      const config = buildVaultConfigFromEnv();
+      expect((config!.auth as any).method).toBe('token');
+    });
+  });
+
+  describe('GCP auth (VAULT_GCP_ROLE)', () => {
+    beforeEach(() => {
+      process.env.VAULT_ADDR = 'https://vault.prod.example.com';
+      process.env.VAULT_GCP_ROLE = 'my-gcp-role';
+    });
+
+    it('should build config with GCP auth', () => {
+      const config = buildVaultConfigFromEnv();
+
+      expect(config).toBeDefined();
+      expect(config!.endpoint).toBe('https://vault.prod.example.com');
+      expect(config!.auth).toEqual({ method: 'gcp', role: 'my-gcp-role' });
+    });
+
+    it('should default refreshBuffer to 60 for GCP auth', () => {
+      const config = buildVaultConfigFromEnv();
+      expect(config!.refreshBuffer).toBe(60);
+    });
+
+    it('should allow overriding refreshBuffer', () => {
+      const config = buildVaultConfigFromEnv({ refreshBuffer: 120 });
+      expect(config!.refreshBuffer).toBe(120);
+    });
+  });
+});

--- a/src/vault/__tests__/secret-refresh-manager.spec.ts
+++ b/src/vault/__tests__/secret-refresh-manager.spec.ts
@@ -1,0 +1,328 @@
+/**
+ * Unit tests for SecretRefreshManager
+ * Uses mocked VaultProvider and VaultCache — no running Vault required.
+ */
+
+import { SecretRefreshManager } from '../secret-refresh-manager';
+import { VaultCache } from '../vault-cache';
+import { VaultProvider } from '../vault-provider';
+import { IVaultSecret, SecretRefreshEvent, VaultCacheEntry, VaultPropertyMetadata } from '../types';
+
+jest.mock('../vault-provider');
+jest.mock('../vault-cache');
+
+function makeMetadata(overrides: Partial<VaultPropertyMetadata> = {}): VaultPropertyMetadata {
+  return {
+    propertyName: 'PROP',
+    propertyType: 'string',
+    path: 'test/path',
+    key: 'value',
+    engine: 'kv-v2',
+    required: true,
+    ...overrides
+  };
+}
+
+function makeSecret(data: Record<string, string>, leaseDuration = 60): IVaultSecret {
+  return {
+    data,
+    leaseDuration,
+    leaseId: leaseDuration > 0 ? 'lease-123' : '',
+    renewable: leaseDuration > 0
+  };
+}
+
+function makeCacheEntry(vaultPath: string, refreshAtOffset = 30000): VaultCacheEntry {
+  const now = Date.now();
+  const secret = makeSecret({ value: 'cached' });
+  return {
+    value: 'cached',
+    secret,
+    vaultPath,
+    propertyName: 'PROP',
+    cachedAt: now,
+    expiresAt: now + 60000,
+    refreshAt: now + refreshAtOffset
+  };
+}
+
+describe('SecretRefreshManager', () => {
+  let manager: SecretRefreshManager;
+  let mockProvider: jest.Mocked<VaultProvider>;
+  let mockCache: jest.Mocked<VaultCache>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    mockProvider = new VaultProvider({} as any) as jest.Mocked<VaultProvider>;
+    mockCache = new VaultCache() as jest.Mocked<VaultCache>;
+
+    manager = new SecretRefreshManager(mockProvider, mockCache, 30);
+  });
+
+  afterEach(() => {
+    manager.shutdown();
+    jest.useRealTimers();
+  });
+
+  describe('onSecretRefreshed', () => {
+    it('should register a callback', () => {
+      const callback = jest.fn();
+      manager.onSecretRefreshed(callback);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should support multiple callbacks', () => {
+      const cb1 = jest.fn();
+      const cb2 = jest.fn();
+      manager.onSecretRefreshed(cb1);
+      manager.onSecretRefreshed(cb2);
+      expect(cb1).not.toHaveBeenCalled();
+      expect(cb2).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('scheduleRefresh', () => {
+    it('should not schedule when cache entry is missing', () => {
+      mockCache.getEntry.mockReturnValue(null as any);
+      manager.scheduleRefresh('PROP', makeMetadata());
+      expect(mockCache.getEntry).toHaveBeenCalledWith('PROP');
+    });
+
+    it('should schedule a timer when cache entry has future refreshAt', () => {
+      mockCache.getEntry.mockReturnValue(makeCacheEntry('secret/data/test/path', 5000));
+      mockProvider.read.mockResolvedValue(makeSecret({ value: 'new' }));
+
+      manager.scheduleRefresh('PROP', makeMetadata());
+
+      expect(mockCache.getEntry).toHaveBeenCalledWith('PROP');
+    });
+
+    it('should execute immediately when refreshAt is in the past', () => {
+      mockCache.getEntry.mockReturnValue(makeCacheEntry('secret/data/test/path', -1000));
+      mockProvider.read.mockResolvedValue(makeSecret({ value: 'new' }));
+
+      manager.scheduleRefresh('PROP', makeMetadata());
+    });
+  });
+
+  describe('path-level atomic refresh', () => {
+    const SHARED_PATH = 'database/creds/my-role';
+
+    beforeEach(() => {
+      mockProvider.read.mockResolvedValue(makeSecret({
+        username: 'new-user',
+        password: 'new-pass'
+      }, 60));
+    });
+
+    it('should refresh all sibling properties from a single Vault read', async () => {
+      const entry = makeCacheEntry(SHARED_PATH, 100);
+      mockCache.getEntry.mockReturnValue(entry);
+
+      const metaUser = makeMetadata({ propertyName: 'DB_USERNAME', key: 'username', engine: 'database', path: 'creds/my-role' });
+      const metaPass = makeMetadata({ propertyName: 'DB_PASSWORD', key: 'password', engine: 'database', path: 'creds/my-role' });
+
+      const target = { DB_USERNAME: 'old-user', DB_PASSWORD: 'old-pass' };
+
+      manager.scheduleRefresh('DB_USERNAME', metaUser, target);
+      manager.scheduleRefresh('DB_PASSWORD', metaPass, target);
+
+      await jest.advanceTimersByTimeAsync(200);
+
+      expect(mockProvider.read).toHaveBeenCalledTimes(1);
+      expect(mockProvider.read).toHaveBeenCalledWith(SHARED_PATH);
+    });
+
+    it('should update target instance properties from the single read', async () => {
+      const entry = makeCacheEntry(SHARED_PATH, 100);
+      mockCache.getEntry.mockReturnValue(entry);
+
+      const metaUser = makeMetadata({ propertyName: 'DB_USERNAME', key: 'username', engine: 'database', path: 'creds/my-role' });
+      const metaPass = makeMetadata({ propertyName: 'DB_PASSWORD', key: 'password', engine: 'database', path: 'creds/my-role' });
+
+      const target = { DB_USERNAME: 'old-user', DB_PASSWORD: 'old-pass' };
+
+      manager.scheduleRefresh('DB_USERNAME', metaUser, target);
+      manager.scheduleRefresh('DB_PASSWORD', metaPass, target);
+
+      await jest.advanceTimersByTimeAsync(200);
+
+      expect(target.DB_USERNAME).toBe('new-user');
+      expect(target.DB_PASSWORD).toBe('new-pass');
+    });
+
+    it('should fire one callback per path with all affected properties', async () => {
+      const events: SecretRefreshEvent[] = [];
+      manager.onSecretRefreshed((e) => { events.push(e); });
+
+      const entry = makeCacheEntry(SHARED_PATH, 100);
+      mockCache.getEntry.mockReturnValue(entry);
+
+      const metaUser = makeMetadata({ propertyName: 'DB_USERNAME', key: 'username', engine: 'database', path: 'creds/my-role' });
+      const metaPass = makeMetadata({ propertyName: 'DB_PASSWORD', key: 'password', engine: 'database', path: 'creds/my-role' });
+
+      manager.scheduleRefresh('DB_USERNAME', metaUser);
+      manager.scheduleRefresh('DB_PASSWORD', metaPass);
+
+      await jest.advanceTimersByTimeAsync(200);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].vaultPath).toBe(SHARED_PATH);
+      expect(events[0].properties).toContain('DB_USERNAME');
+      expect(events[0].properties).toContain('DB_PASSWORD');
+      expect(events[0].engine).toBe('database');
+      expect(events[0].refreshCount).toBe(1);
+      expect(events[0].timestamp).toBeDefined();
+    });
+
+    it('should increment refreshCount on subsequent refreshes', async () => {
+      const events: SecretRefreshEvent[] = [];
+      manager.onSecretRefreshed((e) => { events.push(e); });
+
+      const entry = makeCacheEntry(SHARED_PATH, -100);
+      mockCache.getEntry.mockReturnValue(entry);
+
+      const meta = makeMetadata({ propertyName: 'DB_USERNAME', key: 'username', engine: 'database', path: 'creds/my-role' });
+
+      manager.scheduleRefresh('DB_USERNAME', meta);
+      await jest.advanceTimersByTimeAsync(0);
+
+      manager.scheduleRefresh('DB_USERNAME', meta);
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(2);
+      expect(events[0].refreshCount).toBe(1);
+      expect(events[1].refreshCount).toBe(2);
+    });
+  });
+
+  describe('callback error handling', () => {
+    it('should not throw when a sync callback throws', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      manager.onSecretRefreshed(() => { throw new Error('callback boom'); });
+
+      const entry = makeCacheEntry('secret/data/test', -100);
+      mockCache.getEntry.mockReturnValue(entry);
+      mockProvider.read.mockResolvedValue(makeSecret({ value: 'new' }));
+
+      manager.scheduleRefresh('PROP', makeMetadata());
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('callback boom')
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should not throw when an async callback rejects', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      manager.onSecretRefreshed(async () => { throw new Error('async boom'); });
+
+      const entry = makeCacheEntry('secret/data/test', -100);
+      mockCache.getEntry.mockReturnValue(entry);
+      mockProvider.read.mockResolvedValue(makeSecret({ value: 'new' }));
+
+      manager.scheduleRefresh('PROP', makeMetadata());
+      await jest.advanceTimersByTimeAsync(0);
+
+      // Give the rejected promise a tick to log
+      await Promise.resolve();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('async boom')
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Vault read failure', () => {
+    it('should log error and schedule retry on read failure', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const entry = makeCacheEntry('secret/data/test', -100);
+      mockCache.getEntry.mockReturnValue(entry);
+      mockProvider.read.mockRejectedValue(new Error('Vault unavailable'));
+
+      manager.scheduleRefresh('PROP', makeMetadata());
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to refresh secrets')
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('cancelRefresh', () => {
+    it('should cancel a scheduled refresh', () => {
+      mockCache.getEntry.mockReturnValue(makeCacheEntry('secret/data/test', 30000));
+      manager.scheduleRefresh('PROP', makeMetadata());
+      manager.cancelRefresh('PROP');
+      // No error thrown, timer cleared
+    });
+
+    it('should be a no-op for non-existent property', () => {
+      manager.cancelRefresh('NON_EXISTENT');
+    });
+  });
+
+  describe('getRefreshStatus', () => {
+    it('should return empty array when nothing is cached', () => {
+      mockCache.getCachedProperties.mockReturnValue([]);
+      expect(manager.getRefreshStatus()).toEqual([]);
+    });
+
+    it('should return status for cached properties', () => {
+      const entry = makeCacheEntry('secret/data/test', 30000);
+      mockCache.getCachedProperties.mockReturnValue(['PROP']);
+      mockCache.getEntry.mockReturnValue(entry);
+
+      manager.scheduleRefresh('PROP', makeMetadata());
+
+      const statuses = manager.getRefreshStatus();
+      expect(statuses).toHaveLength(1);
+      expect(statuses[0].propertyName).toBe('PROP');
+      expect(statuses[0].vaultPath).toBe('secret/data/test');
+      expect(statuses[0].scheduled).toBe(true);
+    });
+  });
+
+  describe('getRefreshStatusForProperty', () => {
+    it('should return null for uncached property', () => {
+      mockCache.getEntry.mockReturnValue(null as any);
+      expect(manager.getRefreshStatusForProperty('MISSING')).toBeNull();
+    });
+
+    it('should return status for a cached property', () => {
+      const entry = makeCacheEntry('secret/data/test', 30000);
+      mockCache.getEntry.mockReturnValue(entry);
+
+      manager.scheduleRefresh('PROP', makeMetadata());
+
+      const status = manager.getRefreshStatusForProperty('PROP');
+      expect(status).toBeDefined();
+      expect(status!.propertyName).toBe('PROP');
+      expect(status!.scheduled).toBe(true);
+      expect(status!.refreshCount).toBe(0);
+    });
+  });
+
+  describe('shutdown', () => {
+    it('should clear all timers and callbacks', () => {
+      const cb = jest.fn();
+      manager.onSecretRefreshed(cb);
+
+      mockCache.getEntry.mockReturnValue(makeCacheEntry('secret/data/test', 30000));
+      manager.scheduleRefresh('PROP', makeMetadata());
+
+      manager.shutdown();
+      // After shutdown, advancing time should not trigger anything
+    });
+  });
+});

--- a/src/vault/__tests__/vault-integration-callback.spec.ts
+++ b/src/vault/__tests__/vault-integration-callback.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for VaultIntegration callback wiring.
+ * Mocks VaultProvider, VaultCache, and SecretRefreshManager — no Vault required.
+ */
+
+import { SecretRefreshManager } from '../secret-refresh-manager';
+import { VaultIntegration } from '../vault-integration';
+import { VaultCache } from '../vault-cache';
+import { VaultProvider } from '../vault-provider';
+import { IVaultConfigOptions } from '../types';
+
+jest.mock('../vault-provider');
+jest.mock('../vault-cache');
+jest.mock('../secret-refresh-manager');
+
+const BASE_CONFIG: IVaultConfigOptions = {
+  endpoint: 'http://127.0.0.1:8200',
+  auth: { method: 'token' as const, token: 'test-token' }
+};
+
+describe('VaultIntegration callback wiring', () => {
+  let mockRefreshManager: jest.Mocked<SecretRefreshManager>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockRefreshManager = {
+      onSecretRefreshed: jest.fn(),
+      scheduleRefresh: jest.fn(),
+      cancelRefresh: jest.fn(),
+      getRefreshStatus: jest.fn().mockReturnValue([]),
+      getRefreshStatusForProperty: jest.fn().mockReturnValue(null),
+      shutdown: jest.fn()
+    } as unknown as jest.Mocked<SecretRefreshManager>;
+
+    (SecretRefreshManager as jest.MockedClass<typeof SecretRefreshManager>)
+      .mockImplementation(() => mockRefreshManager);
+  });
+
+  it('should register onSecretRefreshed from config in constructor', () => {
+    const callback = jest.fn();
+    new VaultIntegration({ ...BASE_CONFIG, onSecretRefreshed: callback });
+
+    expect(mockRefreshManager.onSecretRefreshed).toHaveBeenCalledWith(callback);
+  });
+
+  it('should not call onSecretRefreshed when not provided in config', () => {
+    new VaultIntegration(BASE_CONFIG);
+
+    expect(mockRefreshManager.onSecretRefreshed).not.toHaveBeenCalled();
+  });
+
+  it('should delegate runtime onSecretRefreshed to refreshManager', () => {
+    const integration = new VaultIntegration(BASE_CONFIG);
+    const runtimeCallback = jest.fn();
+
+    integration.onSecretRefreshed(runtimeCallback);
+
+    expect(mockRefreshManager.onSecretRefreshed).toHaveBeenCalledWith(runtimeCallback);
+  });
+
+  it('should support both constructor and runtime callbacks', () => {
+    const constructorCb = jest.fn();
+    const runtimeCb = jest.fn();
+
+    const integration = new VaultIntegration({ ...BASE_CONFIG, onSecretRefreshed: constructorCb });
+    integration.onSecretRefreshed(runtimeCb);
+
+    expect(mockRefreshManager.onSecretRefreshed).toHaveBeenCalledTimes(2);
+    expect(mockRefreshManager.onSecretRefreshed).toHaveBeenCalledWith(constructorCb);
+    expect(mockRefreshManager.onSecretRefreshed).toHaveBeenCalledWith(runtimeCb);
+  });
+});

--- a/src/vault/__tests__/vault-integration.test.ts
+++ b/src/vault/__tests__/vault-integration.test.ts
@@ -9,8 +9,9 @@
 
 import { IsString } from 'class-validator';
 
-import { VaultKey, VaultPath } from '../decorators';
-import { IVaultConfigOptions } from '../types';
+import { VaultEngine, VaultKey, VaultPath } from '../decorators';
+import { buildVaultConfigFromEnv } from '../build-vault-config';
+import { IVaultConfigOptions, SecretRefreshEvent } from '../types';
 import { VaultIntegration } from '../vault-integration';
 
 import 'reflect-metadata';
@@ -174,6 +175,177 @@ describeVault('VaultIntegration (requires running Vault)', () => {
       await expect(vaultIntegration.initialize())
         .rejects
         .toThrow(/authentication.*failed/i);
+    });
+  });
+
+  describe('onSecretRefreshed callback', () => {
+    it('should fire callback with correct event when configured via constructor', async () => {
+      const events: SecretRefreshEvent[] = [];
+      const configWithCallback: IVaultConfigOptions = {
+        ...VAULT_CONFIG,
+        onSecretRefreshed: (event) => { events.push(event); }
+      };
+
+      vaultIntegration = new VaultIntegration(configWithCallback);
+      await vaultIntegration.initialize();
+      await vaultIntegration.loadSecrets(TestVaultConfig);
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('should fire callback via runtime registration', async () => {
+      const events: SecretRefreshEvent[] = [];
+
+      vaultIntegration = new VaultIntegration(VAULT_CONFIG);
+      vaultIntegration.onSecretRefreshed((event) => { events.push(event); });
+      await vaultIntegration.initialize();
+      await vaultIntegration.loadSecrets(TestVaultConfig);
+
+      expect(events).toHaveLength(0);
+    });
+  });
+
+  describe('dynamic secrets with TTL-based refresh', () => {
+    /**
+     * Config class using the database engine with dynamic credentials.
+     * database/creds/configit-readonly has a 60s TTL in the test Vault setup.
+     */
+    class DynamicConfig {
+      @VaultPath('creds/configit-readonly')
+      @VaultKey('username')
+      @VaultEngine('database')
+      @IsString()
+        DB_USERNAME!: string;
+
+      @VaultPath('creds/configit-readonly')
+      @VaultKey('password')
+      @VaultEngine('database')
+      @IsString()
+        DB_PASSWORD!: string;
+    }
+
+    it('should load dynamic database credentials', async () => {
+      vaultIntegration = new VaultIntegration({
+        ...VAULT_CONFIG,
+        refreshBuffer: 30
+      });
+      await vaultIntegration.initialize();
+      await vaultIntegration.loadSecrets(DynamicConfig);
+
+      const username = vaultIntegration.getSecret('DB_USERNAME');
+      const password = vaultIntegration.getSecret('DB_PASSWORD');
+
+      expect(username).toBeDefined();
+      expect(username).toMatch(/^v-token-/);
+      expect(password).toBeDefined();
+      expect(password!.length).toBeGreaterThan(0);
+    });
+
+    it('should schedule refresh for dynamic secrets', async () => {
+      vaultIntegration = new VaultIntegration({
+        ...VAULT_CONFIG,
+        refreshBuffer: 30
+      });
+      await vaultIntegration.initialize();
+      await vaultIntegration.loadSecrets(DynamicConfig);
+
+      const health = vaultIntegration.getHealthDetails();
+      expect(health.refreshQueueSize).toBeGreaterThanOrEqual(1);
+
+      const dbUserStatus = health.refreshStatus.find((s) => s.propertyName === 'DB_USERNAME');
+      expect(dbUserStatus).toBeDefined();
+      expect(dbUserStatus!.scheduled).toBe(true);
+      expect(dbUserStatus!.timeUntilRefresh).toBeLessThanOrEqual(60000);
+    });
+
+    it('should perform path-level atomic refresh and fire callback', async () => {
+      const events: SecretRefreshEvent[] = [];
+
+      vaultIntegration = new VaultIntegration({
+        ...VAULT_CONFIG,
+        refreshBuffer: 55, // 60s TTL minus 55s buffer = refresh after ~5s
+        onSecretRefreshed: (event) => { events.push(event); }
+      });
+      await vaultIntegration.initialize();
+      await vaultIntegration.loadSecrets(DynamicConfig);
+
+      const initialUser = vaultIntegration.getSecret('DB_USERNAME');
+      const initialPass = vaultIntegration.getSecret('DB_PASSWORD');
+
+      // Wait for the refresh to trigger (~5s + some margin)
+      await new Promise((resolve) => setTimeout(resolve, 10000));
+
+      const refreshedUser = vaultIntegration.getSecret('DB_USERNAME');
+      const refreshedPass = vaultIntegration.getSecret('DB_PASSWORD');
+
+      // Credentials should have changed
+      expect(refreshedUser).not.toBe(initialUser);
+      expect(refreshedPass).not.toBe(initialPass);
+
+      // Exactly one callback event for the path
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      const dbEvent = events.find((e) => e.engine === 'database');
+      expect(dbEvent).toBeDefined();
+      expect(dbEvent!.properties).toContain('DB_USERNAME');
+      expect(dbEvent!.properties).toContain('DB_PASSWORD');
+      expect(dbEvent!.vaultPath).toContain('configit-readonly');
+      expect(dbEvent!.refreshCount).toBeGreaterThanOrEqual(1);
+    }, 20000);
+  });
+
+  describe('buildVaultConfigFromEnv end-to-end', () => {
+    const savedEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      savedEnv.VAULT_ADDR = process.env.VAULT_ADDR;
+      savedEnv.VAULT_TOKEN = process.env.VAULT_TOKEN;
+      savedEnv.VAULT_GCP_ROLE = process.env.VAULT_GCP_ROLE;
+    });
+
+    afterEach(() => {
+      for (const [key, val] of Object.entries(savedEnv)) {
+        if (val !== undefined) {
+          process.env[key] = val;
+        } else {
+          delete process.env[key];
+        }
+      }
+    });
+
+    it('should produce a config that VaultIntegration can use', async () => {
+      process.env.VAULT_ADDR = 'http://127.0.0.1:8200';
+      process.env.VAULT_TOKEN = 'configit-dev-token';
+      delete process.env.VAULT_GCP_ROLE;
+
+      const config = buildVaultConfigFromEnv();
+      expect(config).toBeDefined();
+
+      vaultIntegration = new VaultIntegration(config!);
+      await vaultIntegration.initialize();
+      expect(vaultIntegration.isInitialized()).toBe(true);
+
+      await vaultIntegration.loadSecrets(TestVaultConfig);
+      expect(vaultIntegration.getSecret('API_KEY')).toBe('test-api-key-123');
+    });
+
+    it('should wire onSecretRefreshed callback through to VaultIntegration', async () => {
+      process.env.VAULT_ADDR = 'http://127.0.0.1:8200';
+      process.env.VAULT_TOKEN = 'configit-dev-token';
+      delete process.env.VAULT_GCP_ROLE;
+
+      const events: SecretRefreshEvent[] = [];
+      const config = buildVaultConfigFromEnv({
+        onSecretRefreshed: (event) => { events.push(event); }
+      });
+      expect(config).toBeDefined();
+      expect(config!.onSecretRefreshed).toBeDefined();
+
+      vaultIntegration = new VaultIntegration(config!);
+      await vaultIntegration.initialize();
+      await vaultIntegration.loadSecrets(TestVaultConfig);
+
+      // No events yet (KV secrets have no TTL-based refresh in this setup)
+      expect(events).toHaveLength(0);
     });
   });
 });

--- a/src/vault/build-vault-config.ts
+++ b/src/vault/build-vault-config.ts
@@ -1,0 +1,73 @@
+/**
+ * buildVaultConfigFromEnv
+ *
+ * Builds IVaultConfigOptions from standard environment variables.
+ * Returns undefined when Vault is not configured, causing configit
+ * to fall back to env vars / config files.
+ *
+ * Supported auth flows (checked in order):
+ *   1. VAULT_TOKEN         → Token auth (local development)
+ *   2. VAULT_GCP_ROLE      → GCP IAM auth (production / GKE)
+ *
+ * Common env vars:
+ *   VAULT_ADDR             → Vault server URL (required)
+ */
+
+import { IVaultConfigOptions, IVaultFallbackConfig, SecretRefreshCallback } from './types';
+
+export interface IBuildVaultConfigOptions {
+  /** Seconds before expiry to trigger refresh. Default: 10 (token) / 60 (GCP) */
+  refreshBuffer?: number;
+
+  /** Fallback behavior when Vault is unavailable */
+  fallback?: IVaultFallbackConfig;
+
+  /** Callback fired when secrets are refreshed */
+  onSecretRefreshed?: SecretRefreshCallback;
+}
+
+const DEFAULT_FALLBACK: IVaultFallbackConfig = {
+  required: false,
+  useCacheOnFailure: true,
+  maxCacheAge: 3600000,
+  failFast: false
+};
+
+export function buildVaultConfigFromEnv(
+  options?: IBuildVaultConfigOptions
+): IVaultConfigOptions | undefined {
+  const vaultAddr = process.env.VAULT_ADDR;
+  const vaultToken = process.env.VAULT_TOKEN;
+  const vaultRole = process.env.VAULT_GCP_ROLE;
+
+  if (!vaultAddr) {
+    // eslint-disable-next-line no-undefined
+    return undefined;
+  }
+
+  const fallback = options?.fallback ?? DEFAULT_FALLBACK;
+  const onSecretRefreshed = options?.onSecretRefreshed;
+
+  if (vaultToken) {
+    return {
+      endpoint: vaultAddr,
+      auth: { method: 'token' as const, token: vaultToken },
+      refreshBuffer: options?.refreshBuffer ?? 10,
+      fallback,
+      onSecretRefreshed
+    };
+  }
+
+  if (vaultRole) {
+    return {
+      endpoint: vaultAddr,
+      auth: { method: 'gcp' as const, role: vaultRole },
+      refreshBuffer: options?.refreshBuffer ?? 60,
+      fallback,
+      onSecretRefreshed
+    };
+  }
+
+  // eslint-disable-next-line no-undefined
+  return undefined;
+}

--- a/src/vault/index.ts
+++ b/src/vault/index.ts
@@ -29,3 +29,7 @@ export { VaultProvider } from './vault-provider';
 export { VaultCache } from './vault-cache';
 export { SecretRefreshManager } from './secret-refresh-manager';
 export { VaultIntegration } from './vault-integration';
+
+// Helpers
+export { buildVaultConfigFromEnv } from './build-vault-config';
+export type { IBuildVaultConfigOptions } from './build-vault-config';

--- a/src/vault/secret-refresh-manager.ts
+++ b/src/vault/secret-refresh-manager.ts
@@ -1,9 +1,19 @@
 /**
  * SecretRefreshManager
- * Manages background refresh of Vault secrets based on TTL
+ * Manages background refresh of Vault secrets based on TTL.
+ *
+ * Refreshes are path-aware: when a secret at a given Vault path is refreshed,
+ * ALL properties sharing that path are updated from the same Vault read.
+ * This prevents credential mismatch (e.g. username from one read, password
+ * from another) for engines like `database` where each read generates new creds.
  */
 
-import { IRefreshStatus, VaultPropertyMetadata } from './types';
+import {
+  IRefreshStatus,
+  SecretRefreshCallback,
+  SecretRefreshEvent,
+  VaultPropertyMetadata
+} from './types';
 import { VaultCache } from './vault-cache';
 import { VaultProvider } from './vault-provider';
 
@@ -13,9 +23,6 @@ interface IRefreshContext {
   fullPath: string;
 }
 
-/**
- * SecretRefreshManager - Handles TTL-based secret refresh scheduling
- */
 export class SecretRefreshManager {
   private refreshTimers: Map<string, NodeJS.Timeout> = new Map();
   private refreshLocks: Map<string, Promise<void>> = new Map();
@@ -24,45 +31,45 @@ export class SecretRefreshManager {
   private refreshContexts: Map<string, IRefreshContext> = new Map();
   private vaultProvider: VaultProvider;
   private cache: VaultCache;
-  private refreshBuffer: number; // Default refresh buffer in seconds
+  private refreshBuffer: number;
+  private onRefreshCallbacks: SecretRefreshCallback[] = [];
 
   constructor(provider: VaultProvider, cache: VaultCache, refreshBuffer?: number) {
     this.vaultProvider = provider;
     this.cache = cache;
-    // Default: min(10% of TTL, 300s) - but we'll use a fixed buffer per secret
-    this.refreshBuffer = refreshBuffer || 300; // 5 minutes default
+    this.refreshBuffer = refreshBuffer || 300;
   }
 
   /**
-   * Schedule refresh for a secret based on TTL
+   * Register a callback to be invoked after secrets are refreshed.
+   * Multiple callbacks can be registered.
    */
+  onSecretRefreshed(callback: SecretRefreshCallback): void {
+    this.onRefreshCallbacks.push(callback);
+  }
+
   scheduleRefresh(propertyName: string, metadata: VaultPropertyMetadata, targetInstance?: object): void {
     const entry = this.cache.getEntry(propertyName);
     if (!entry) {
-      return; // No cache entry to refresh
+      return;
     }
 
-    // Store context for refresh
     this.refreshContexts.set(propertyName, {
       metadata,
       targetInstance,
       fullPath: entry.vaultPath
     });
 
-    // Cancel existing refresh if any
     this.cancelRefresh(propertyName);
 
-    // Calculate refresh time
     const now = Date.now();
     const timeUntilRefresh = Math.max(0, entry.refreshAt - now);
 
     if (timeUntilRefresh <= 0) {
-      // Already past refresh time, refresh immediately
       this.executeRefresh(propertyName);
       return;
     }
 
-    // Schedule refresh
     const timer = setTimeout(() => {
       this.executeRefresh(propertyName);
     }, timeUntilRefresh);
@@ -70,9 +77,6 @@ export class SecretRefreshManager {
     this.refreshTimers.set(propertyName, timer);
   }
 
-  /**
-   * Cancel scheduled refresh for a property
-   */
   cancelRefresh(propertyName: string): void {
     const timer = this.refreshTimers.get(propertyName);
     if (timer) {
@@ -81,77 +85,123 @@ export class SecretRefreshManager {
     }
   }
 
-  /**
-   * Execute refresh for a secret (with locking to prevent concurrent refreshes)
-   */
   private async executeRefresh(propertyName: string): Promise<void> {
-    // Check if refresh is already in progress
-    const existingLock = this.refreshLocks.get(propertyName);
-    if (existingLock) {
-      await existingLock;
-      return; // Refresh already completed
+    const context = this.refreshContexts.get(propertyName);
+    if (!context) {
+      return;
     }
 
-    // Create refresh lock
-    const refreshPromise = this.performRefresh(propertyName)
+    // Lock by path so sibling properties don't trigger duplicate reads
+    const lockKey = `path:${ context.fullPath }`;
+    const existingLock = this.refreshLocks.get(lockKey);
+    if (existingLock) {
+      await existingLock;
+      return;
+    }
+
+    const refreshPromise = this.performPathRefresh(context.fullPath)
       .finally(() => {
-        this.refreshLocks.delete(propertyName);
-        this.refreshTimers.delete(propertyName);
+        this.refreshLocks.delete(lockKey);
       });
 
-    this.refreshLocks.set(propertyName, refreshPromise);
+    this.refreshLocks.set(lockKey, refreshPromise);
     await refreshPromise;
   }
 
   /**
-   * Perform the actual refresh operation
+   * Refresh ALL properties that share the given Vault path in a single read.
    */
-  private async performRefresh(propertyName: string): Promise<void> {
-    const context = this.refreshContexts.get(propertyName);
-    if (!context) {
-      console.error(`No refresh context for ${ propertyName }`);
+  private async performPathRefresh(fullPath: string): Promise<void> {
+    const siblingProperties = this.getSiblingsForPath(fullPath);
+    if (siblingProperties.length === 0) {
       return;
     }
 
-    const { metadata, targetInstance, fullPath } = context;
-    const refreshCount = (this.refreshCounts.get(propertyName) || 0) + 1;
-    this.refreshCounts.set(propertyName, refreshCount);
+    const pathRefreshCount = (this.refreshCounts.get(fullPath) || 0) + 1;
+    this.refreshCounts.set(fullPath, pathRefreshCount);
 
     try {
-      // Read fresh secret from Vault (using full path)
       const secret = await this.vaultProvider.read(fullPath);
+      const updatedProperties: string[] = [];
+      let engine = siblingProperties[0].metadata.engine;
 
-      // Update cache
-      this.cache.set(propertyName, fullPath, secret, metadata);
+      for (const { propertyName, metadata, targetInstance } of siblingProperties) {
+        this.cache.set(propertyName, fullPath, secret, metadata);
 
-      // Update target instance if provided
-      if (targetInstance) {
-        const key = metadata.key || metadata.propertyName;
-        const value = secret.data[key];
-        (targetInstance as any)[propertyName] = value;
+        if (targetInstance) {
+          const key = metadata.key || metadata.propertyName;
+          const value = secret.data[key];
+          (targetInstance as any)[propertyName] = value;
+        }
+
+        updatedProperties.push(propertyName);
+        engine = metadata.engine;
+
+        this.cancelRefresh(propertyName);
+        this.refreshTimers.delete(propertyName);
       }
 
-      // Record refresh time
-      this.lastRefreshTimes.set(propertyName, Date.now());
+      const now = Date.now();
+      this.lastRefreshTimes.set(fullPath, now);
 
-      // Reschedule next refresh
-      this.scheduleRefresh(propertyName, metadata, targetInstance);
-    } catch (error: any) {
-      // Log error (sanitized)
-      const errorMessage = error?.message || 'Unknown error';
-      console.error(`Failed to refresh secret for ${ propertyName }: ${ this.sanitizeError(errorMessage) }`);
-
-      // Retry with exponential backoff
-      const retryDelay = Math.min(1000 * Math.pow(2, refreshCount - 1), 30000); // Max 30s
-      setTimeout(() => {
+      // Reschedule all sibling properties
+      for (const { propertyName, metadata, targetInstance } of siblingProperties) {
         this.scheduleRefresh(propertyName, metadata, targetInstance);
+      }
+
+      // Fire callbacks once per path
+      const event: SecretRefreshEvent = {
+        vaultPath: fullPath,
+        properties: updatedProperties,
+        engine,
+        timestamp: new Date(now).toISOString(),
+        refreshCount: pathRefreshCount
+      };
+
+      for (const callback of this.onRefreshCallbacks) {
+        try {
+          const result = callback(event);
+          if (result && typeof (result as Promise<void>).catch === 'function') {
+            (result as Promise<void>).catch((err) => {
+              console.error(`Secret refresh callback error for ${ fullPath }: ${ this.sanitizeError(err?.message || 'Unknown') }`);
+            });
+          }
+        } catch (err: any) {
+          console.error(`Secret refresh callback error for ${ fullPath }: ${ this.sanitizeError(err?.message || 'Unknown') }`);
+        }
+      }
+    } catch (error: any) {
+      const errorMessage = error?.message || 'Unknown error';
+      console.error(`Failed to refresh secrets for path ${ this.sanitizePath(fullPath) }: ${ this.sanitizeError(errorMessage) }`);
+
+      const retryDelay = Math.min(1000 * Math.pow(2, pathRefreshCount - 1), 30000);
+      setTimeout(() => {
+        for (const { propertyName, metadata, targetInstance } of siblingProperties) {
+          this.scheduleRefresh(propertyName, metadata, targetInstance);
+        }
       }, retryDelay);
     }
   }
 
   /**
-   * Get refresh status for all secrets
+   * Find all properties that share the given Vault path.
    */
+  private getSiblingsForPath(fullPath: string): Array<{ propertyName: string; metadata: VaultPropertyMetadata; targetInstance?: object }> {
+    const siblings: Array<{ propertyName: string; metadata: VaultPropertyMetadata; targetInstance?: object }> = [];
+
+    for (const [ propertyName, context ] of this.refreshContexts.entries()) {
+      if (context.fullPath === fullPath) {
+        siblings.push({
+          propertyName,
+          metadata: context.metadata,
+          targetInstance: context.targetInstance
+        });
+      }
+    }
+
+    return siblings;
+  }
+
   getRefreshStatus(): IRefreshStatus[] {
     const statuses: IRefreshStatus[] = [];
     const cachedProperties = this.cache.getCachedProperties();
@@ -173,17 +223,14 @@ export class SecretRefreshManager {
         scheduled: timer !== undefined,
         refreshAt,
         timeUntilRefresh,
-        lastRefresh: this.lastRefreshTimes.get(propertyName) || entry.cachedAt,
-        refreshCount: this.refreshCounts.get(propertyName) || 0
+        lastRefresh: this.lastRefreshTimes.get(entry.vaultPath) || entry.cachedAt,
+        refreshCount: this.refreshCounts.get(entry.vaultPath) || 0
       });
     }
 
     return statuses;
   }
 
-  /**
-   * Get refresh status for a specific property
-   */
   getRefreshStatusForProperty(propertyName: string): IRefreshStatus | null {
     const entry = this.cache.getEntry(propertyName);
     if (!entry) {
@@ -201,17 +248,13 @@ export class SecretRefreshManager {
       scheduled: timer !== undefined,
       refreshAt,
       timeUntilRefresh,
-      lastRefresh: this.lastRefreshTimes.get(propertyName) || entry.cachedAt,
-      refreshCount: this.refreshCounts.get(propertyName) || 0
+      lastRefresh: this.lastRefreshTimes.get(entry.vaultPath) || entry.cachedAt,
+      refreshCount: this.refreshCounts.get(entry.vaultPath) || 0
     };
   }
 
-  /**
-   * Stop all refresh workers
-   */
   shutdown(): void {
-    // Cancel all timers
-    for (const [ propertyName, timer ] of this.refreshTimers.entries()) {
+    for (const [ , timer ] of this.refreshTimers.entries()) {
       clearTimeout(timer);
     }
 
@@ -219,13 +262,10 @@ export class SecretRefreshManager {
     this.refreshLocks.clear();
     this.refreshCounts.clear();
     this.lastRefreshTimes.clear();
+    this.onRefreshCallbacks = [];
   }
 
-  /**
-   * Sanitize error message (remove potential secret values)
-   */
   private sanitizeError(message: string): string {
-    // Remove potential secret values from error messages
     const sensitivePatterns = [ /password/i, /secret/i, /key/i, /token/i, /credential/i ];
     let sanitized = message;
 
@@ -237,5 +277,17 @@ export class SecretRefreshManager {
     });
 
     return sanitized;
+  }
+
+  private sanitizePath(path: string): string {
+    const segments = path.split('/');
+    if (segments.length > 0) {
+      const lastSegment = segments[segments.length - 1];
+      const sensitivePatterns = [ /password/i, /secret/i, /key/i, /token/i, /credential/i ];
+      if (sensitivePatterns.some((pattern) => pattern.test(lastSegment))) {
+        segments[segments.length - 1] = '***';
+      }
+    }
+    return segments.join('/');
   }
 }

--- a/src/vault/types.ts
+++ b/src/vault/types.ts
@@ -68,6 +68,14 @@ export interface IVaultConfigOptions {
    * Circuit breaker configuration
    */
   circuitBreaker?: ICircuitBreakerConfig;
+
+  /**
+   * Callback invoked when a secret is refreshed.
+   * Fired once per Vault path after all properties from that path are updated.
+   * Config values are already set when this fires, so consumers can
+   * safely read the new values from the config instance.
+   */
+  onSecretRefreshed?: SecretRefreshCallback;
 }
 
 /**
@@ -224,6 +232,36 @@ export interface IRetryPolicy {
   /** Default: ['ECONNREFUSED', 'ETIMEDOUT', '5xx'] */
   retryableErrors: string[];
 }
+
+/**
+ * Event emitted when a Vault secret is refreshed.
+ * Fired once per Vault path (not per property), so consumers
+ * can react to credential rotation (e.g., reconnect a database pool).
+ *
+ * Secret values are intentionally excluded for security.
+ */
+export interface SecretRefreshEvent {
+  /** The Vault path that was refreshed (e.g. 'database/creds/my-role') */
+  vaultPath: string;
+
+  /** Config property names updated from this path (e.g. ['DB_USERNAME', 'DB_PASSWORD']) */
+  properties: string[];
+
+  /** Vault engine type */
+  engine: VaultEngineType;
+
+  /** ISO timestamp of the refresh */
+  timestamp: string;
+
+  /** Number of times this path has been refreshed (1-based) */
+  refreshCount: number;
+}
+
+/**
+ * Callback invoked when Vault secrets are refreshed.
+ * Config values are already updated when this fires.
+ */
+export type SecretRefreshCallback = (event: SecretRefreshEvent) => void | Promise<void>;
 
 /**
  * Circuit breaker configuration

--- a/src/vault/vault-integration.ts
+++ b/src/vault/vault-integration.ts
@@ -8,6 +8,7 @@ import { SecretRefreshManager } from './secret-refresh-manager';
 import {
   IVaultConfigOptions,
   IVaultHealthDetails,
+  SecretRefreshCallback,
   VaultHealth,
   VaultPropertyMetadata
 } from './types';
@@ -31,8 +32,12 @@ export class VaultIntegration {
     this.config = config;
     this.provider = new VaultProvider(config);
     this.cache = new VaultCache();
-    const refreshBuffer = config.refreshBuffer || 300; // Default 5 minutes
+    const refreshBuffer = config.refreshBuffer || 300;
     this.refreshManager = new SecretRefreshManager(this.provider, this.cache, refreshBuffer);
+
+    if (config.onSecretRefreshed) {
+      this.refreshManager.onSecretRefreshed(config.onSecretRefreshed);
+    }
   }
 
   /**
@@ -169,6 +174,14 @@ export class VaultIntegration {
         this.refreshManager.scheduleRefresh(propertyName, propertyWithDefaults, instance);
       }
     }
+  }
+
+  /**
+   * Register a callback for secret refresh events.
+   * Can be called before or after initialization.
+   */
+  onSecretRefreshed(callback: SecretRefreshCallback): void {
+    this.refreshManager.onSecretRefreshed(callback);
   }
 
   /**


### PR DESCRIPTION
### Description
- **`onSecretRefreshed` callback**: New `SecretRefreshEvent` type and `SecretRefreshCallback` allowing consumers to react when Vault secrets are refreshed (e.g., reconnect a database pool). Can be registered via `IVaultConfigOptions.onSecretRefreshed` at construction or `configService.onSecretRefreshed()` at runtime.
- **Path-level atomic refresh**: Refactored `SecretRefreshManager` so that all properties sharing the same Vault path (e.g., `DB_USERNAME` and `DB_PASSWORD` from `database/creds/my-role`) are updated from a **single** Vault read. This prevents credential mismatch where username comes from one lease and password from another. One callback event fires per path, listing all affected properties.
- **`buildVaultConfigFromEnv()` helper**: New utility that builds `IVaultConfigOptions` from standard environment variables (`VAULT_ADDR`, `VAULT_TOKEN`, `VAULT_GCP_ROLE`). Returns `undefined` when Vault is not configured, so configit falls back to env vars/config files. Reduces boilerplate across microservices.
- **Bug fix**: `jest-stare` 2.5.0 → 2.5.3 to fix `util.isNullOrUndefined` crash on Node 22+.
- **Test script fix**: Corrected `@VaultPath` prefixes in `test-vault-dynamic.ts` that caused double-prefixed paths (`secret/data/secret/data/...`).
